### PR TITLE
Made IPVS and RSVS public as we want these in some DAs

### DIFF
--- a/Kemp/IPVSClass.mpx
+++ b/Kemp/IPVSClass.mpx
@@ -28,7 +28,7 @@
           ServiceKey = vSip
           
         -->
-        <ClassType ID="QND.Network.Kemp.LoadMaster.IPVS" Base="Network!System.NetworkManagement.LogicalDevice" Accessibility="Internal" Abstract="false" Hosted="true" Singleton="false">
+        <ClassType ID="QND.Network.Kemp.LoadMaster.IPVS" Base="Network!System.NetworkManagement.LogicalDevice" Accessibility="Public" Abstract="false" Hosted="true" Singleton="false">
           <Property ID="Protocol" Type="string" Key="false" /> <!-- vSprotocol -->
           <Property ID="ProtocolId" Type="string" Key="false" />          
           <Property ID="IP" Type="string" Key="false" />

--- a/Kemp/RSVSClass.mpx
+++ b/Kemp/RSVSClass.mpx
@@ -28,7 +28,7 @@
           ServiceKey = vSip
           
         -->
-        <ClassType ID="QND.Network.Kemp.LoadMaster.RSVS" Base="System!System.LogicalHardware" Accessibility="Internal" Abstract="false" Hosted="true" Singleton="false">
+        <ClassType ID="QND.Network.Kemp.LoadMaster.RSVS" Base="System!System.LogicalHardware" Accessibility="Public" Abstract="false" Hosted="true" Singleton="false">
           <Property ID="Description" Type="string" Key="false" CaseSensitive="false" MinLength="0" MaxLength="256" />
           <Property ID="RSKey" Type="string" Key="true" CaseSensitive="false" MinLength="0" MaxLength="256" />
           <Property ID="Index" Type="string" Key="false" CaseSensitive="false" MinLength="0" MaxLength="256" />


### PR DESCRIPTION
We need to be able to add the Real Server and VIP-objects into our Distributed Applications we're building. 
Made them Public instead of internal.